### PR TITLE
refactor(names): remove name aliases

### DIFF
--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -86,18 +86,13 @@ export default class Deployment extends pulumi.ComponentResource {
           },
         },
       }
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `metrics-server-${name}`}],
-    });
+    }, defaultOptions);
 
     if (args.podDisruptionBudget.enabled) {
       const pdb = new k8s.policy.v1beta1.PodDisruptionBudget(name,
         args.podDisruptionBudget.config,
-      {
-        ...defaultOptions,
-        aliases: [{ name: `${name}-poddisruptionbudget`}],
-      });
+        defaultOptions,
+      );
       this.podDisruptionBudget = pdb;
     } else {
       this.podDisruptionBudget = undefined;

--- a/src/psp.ts
+++ b/src/psp.ts
@@ -40,9 +40,6 @@ export default class Psp extends pulumi.ComponentResource {
           max: 65536,
         }],
       },
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `${name}-podSecurityPolicy`}],
-    });
+    }, defaultOptions);
   }
 }

--- a/src/rbac.ts
+++ b/src/rbac.ts
@@ -39,10 +39,7 @@ export default class Rbac extends pulumi.ComponentResource {
         }
       },
       rules: clusterRoleRules,
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `${name}-clusterRole`}],
-    });
+    }, defaultOptions);
 
     const aggregatedMetricsReaderClusterRole = new k8s.rbac.v1.ClusterRole(`${name}-aggregated`, {
       metadata: {
@@ -59,10 +56,7 @@ export default class Rbac extends pulumi.ComponentResource {
         resources: ['pods'],
         verbs: ['get', 'list', 'watch']
       }]
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `${name}-aggregatedMetricsReaderClusterRole`}],
-    });
+    }, defaultOptions);
 
     this.serviceAccount = new k8s.core.v1.ServiceAccount(name, {
       metadata: {
@@ -72,10 +66,7 @@ export default class Rbac extends pulumi.ComponentResource {
           app: name,
         }
       },
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `${name}-serviceAccount`}],
-    });
+    }, defaultOptions);
 
     const clusterRoleBinding = new k8s.rbac.v1.ClusterRoleBinding(name, {
       metadata: {
@@ -94,10 +85,7 @@ export default class Rbac extends pulumi.ComponentResource {
         name: this.serviceAccount.metadata.name,
         namespace: args.namespace,
       }]
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `${name}-clusterrolebinding`}],
-    });
+    }, defaultOptions);
 
     const authDelegatorClusterRoleBinding = new k8s.rbac.v1.ClusterRoleBinding(`${name}-auth`, {
       metadata: {
@@ -116,11 +104,8 @@ export default class Rbac extends pulumi.ComponentResource {
         kind: 'ServiceAccount',
         name: this.serviceAccount.metadata.name,
         namespace: args.namespace,
-      }]
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `${name}-authDelegatorClusterRoleBinding`}],
-    });
+      }],
+    }, defaultOptions);
 
     const roleBinding = new k8s.rbac.v1.RoleBinding(name, {
       metadata: {
@@ -139,10 +124,7 @@ export default class Rbac extends pulumi.ComponentResource {
         name: this.serviceAccount.metadata.name,
         namespace: args.namespace,
       }],
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `${name}-rolebinding`}],
-    });
+    }, defaultOptions);
 
     this.registerOutputs({
       serviceAccount: this.serviceAccount,

--- a/src/service.ts
+++ b/src/service.ts
@@ -35,10 +35,7 @@ export default class Service extends pulumi.ComponentResource {
         },
         type: args.type,
       },
-    }, {
-      ...defaultOptions,
-      aliases: [{ name: `metrics-server-${name}`}],
-    });
+    }, defaultOptions);
 
     if (args.createApiService) {
       this.apiService = new k8s.apiregistration.v1beta1.APIService(name, {
@@ -62,7 +59,6 @@ export default class Service extends pulumi.ComponentResource {
       }, {
         ...defaultOptions,
         deleteBeforeReplace: true,
-        aliases: [{ name: `metrics-server-${name}`}],
       });
     } else {
       this.apiService = undefined;


### PR DESCRIPTION
Remove all name alises from last name change.

BREAKING CHANGE: Aliases from the last name change have been removed.  To avoid issues, upgrade to
that version (v1.9.1) first.